### PR TITLE
#3254 - Laurel Rose Infinity Points Project Updates

### DIFF
--- a/WebExtensionTests/Controllers/WebHookControllerTests.cs
+++ b/WebExtensionTests/Controllers/WebHookControllerTests.cs
@@ -41,14 +41,14 @@ namespace WebExtensionTests.Controllers
         {
             // Arrange
             _distributedLockingServiceMock
-                .Setup(x => x.CreateDistributedLockAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Setup(x => x.CreateDistributedLockAsync(It.IsAny<string>(), null))
                 .ReturnsAsync((MockSqlDistributedLock)null);
 
             // Act
             await _webHookController.DailyEvent(new DailyEvent());
 
             // Assert
-            _distributedLockingServiceMock.Verify(x => x.CreateDistributedLockAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+            _distributedLockingServiceMock.Verify(x => x.CreateDistributedLockAsync(It.IsAny<string>(), null), Times.Once);
             _rewardPointServiceMock.Verify(x => x.AwardRewardPointCreditsAsync(It.IsAny<int?>()), Times.Never);
         }
 
@@ -57,14 +57,14 @@ namespace WebExtensionTests.Controllers
         {
             // Arrange
             _distributedLockingServiceMock
-                .Setup(x => x.CreateDistributedLockAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()))
+                .Setup(x => x.CreateDistributedLockAsync(It.IsAny<string>(), null))
                 .ReturnsAsync(new MockSqlDistributedLock());
 
             // Act
             await _webHookController.DailyEvent(new DailyEvent());
 
             // Assert
-            _distributedLockingServiceMock.Verify(x => x.CreateDistributedLockAsync(It.IsAny<string>(), It.IsAny<TimeSpan>()), Times.Once);
+            _distributedLockingServiceMock.Verify(x => x.CreateDistributedLockAsync(It.IsAny<string>(), null), Times.Once);
             _rewardPointServiceMock.Verify(x => x.AwardRewardPointCreditsAsync(It.IsAny<int?>()), Times.Once);
         }
 


### PR DESCRIPTION
We have been auditing the Infinity Credits that are being loaded and noticed two issues.
 
1) We treat Rep first-orders like customer first-time orders. It looks like first orders that include a RepKit are being excluded from earning Infinity Points. Please make sure rep first orders receive Infinity Points for none RepKit items within that first order.

2) All Infinity Packs orders should be treated as a first time order, no matter when they are ordered (ID: 15, 16, 4). Those ID should receive the 160 points as specified in the Customer Field Data (2).