### PR TITLE
Reward Point Repository - Removing Extra Parenthesis Causing Errors

### DIFF
--- a/WebExtension/Services/RewardPoints/RewardPointRepository.cs
+++ b/WebExtension/Services/RewardPoints/RewardPointRepository.cs
@@ -67,7 +67,7 @@ FROM [dbo].[CRM_CommissionPeriods]
 @"SELECT I.[recordnumber] AS ItemId, CAST(C.[Field2] AS FLOAT) AS FirstTimeItemDiscount
 FROM [dbo].[INV_Inventory] I
 JOIN [dbo].[INV_CustomFields] C ON C.[ItemID] = I.[recordnumber] AND ISNULL(C.[Field2], '') != ''
-WHERE I.[recordnumber] IN (@ItemIds);";
+WHERE I.[recordnumber] IN @ItemIds;";
 
             var itemDiscountsMap = new Dictionary<int, double>();
             using var dbConnection = new SqlConnection(_dataService.GetClientConnectionString().ConfigureAwait(false).GetAwaiter().GetResult());
@@ -86,7 +86,7 @@ WHERE I.[recordnumber] IN (@ItemIds);";
 @"SELECT I.[recordnumber] AS ItemId, CAST(C.[Field1] AS FLOAT) AS FirstTimeOrderDiscount
 FROM [dbo].[INV_Inventory] I
 JOIN [dbo].[INV_CustomFields] C ON C.[ItemID] = I.[recordnumber] AND ISNULL(C.[Field1], '') != ''
-WHERE I.[recordnumber] IN (@ItemIds);";
+WHERE I.[recordnumber] IN @ItemIds;";
 
             var orderDiscountsMap = new Dictionary<int, double>();
             using var dbConnection = new SqlConnection(_dataService.GetClientConnectionString().ConfigureAwait(false).GetAwaiter().GetResult());


### PR DESCRIPTION
![7cff685f-e25f-4628-9471-4c6071b484bc](https://github.com/laurelrose/directscale/assets/109990959/b57ed88c-e0be-44e3-bf7b-8bee6d9e9d6b)

Sure enough there were parenthesis around the Dapper variables in a couple queries.